### PR TITLE
Adding default SMCP yaml which uses Kiali and improving robustness

### DIFF
--- a/service-mesh-delete.sh
+++ b/service-mesh-delete.sh
@@ -3,13 +3,22 @@
 # Not deleted SMMR may cause namespace deletion failure
 oc delete smmr -n mesh-control-plane --all
 oc delete smcp -n mesh-control-plane basic-install
+oc delete smcp -n mesh-control-plane default-install
+# we want to be sure that kiali CR is gone before removing the namespace to avoid being stuck in terminating stage
+# if it happens, following should fix it: oc patch kiali kiali -n mesh-control-plane -p '{"metadata":{"finalizers": []}}' --type=merge
+while oc get kiali kiali -n mesh-control-plane &> /dev/null
+do
+  echo "Waiting for Kiali CR to be deleted"
+  sleep 10
+done
+oc delete namespace mesh-control-plane mesh-scale
+
 oc delete subs -n openshift-operators servicemeshoperator kiali-ossm jaeger-product elasticsearch-operator
 oc delete subs -n openshift-operators servicemeshoperator
 oc delete csv -n openshift-operators -l operators.coreos.com/elasticsearch-operator.openshift-operators
 oc delete csv -n openshift-operators -l operators.coreos.com/jaeger-product.openshift-operators
 oc delete csv -n openshift-operators -l operators.coreos.com/kiali-ossm.openshift-operators
 oc delete csv -n openshift-operators -l operators.coreos.com/servicemeshoperator.openshift-operators
-oc delete namespace mesh-control-plane mesh-scale
 
 # These two should be removed by the operator, so just in case...
 oc delete mutatingwebhookconfiguration -l app.kubernetes.io/instance=mesh-control-plane
@@ -24,3 +33,14 @@ oc delete daemonset -n openshift-operators istio-node
 oc delete sa -n openshift-operators istio-operator
 oc delete sa -n openshift-operators istio-cni
 oc delete service maistra-admission-controller
+
+# Removing remaining resources (https://docs.openshift.com/container-platform/4.10/service_mesh/v2x/removing-ossm.html)
+oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
+oc delete clusterrole istio-view istio-edit
+oc delete clusterrole jaegers.jaegertracing.io-v1-admin jaegers.jaegertracing.io-v1-crdview jaegers.jaegertracing.io-v1-edit jaegers.jaegertracing.io-v1-view
+oc get crds -o name | grep '.*\.istio\.io' | xargs -r -n 1 oc delete
+oc get crds -o name | grep '.*\.maistra\.io' | xargs -r -n 1 oc delete
+oc get crds -o name | grep '.*\.kiali\.io' | xargs -r -n 1 oc delete
+oc delete crds jaegers.jaegertracing.io
+oc delete secret -n openshift-operators maistra-operator-serving-cert
+oc delete cm -n openshift-operators maistra-operator-cabundle

--- a/smcp_v2.yaml
+++ b/smcp_v2.yaml
@@ -15,7 +15,7 @@ spec:
           type: Memory
           #type: Elasticsearch
     kiali:
-      enabled: false
+      enabled: ${KIALI_ENABLED}
     prometheus:
       install:
         service:

--- a/smcp_v2_default.yaml
+++ b/smcp_v2_default.yaml
@@ -1,0 +1,27 @@
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: default-install
+  namespace: mesh-control-plane
+spec:
+  addons:
+    grafana:
+      enabled: true
+    jaeger:
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+    prometheus:
+      enabled: true
+  policy:
+    type: Istiod
+  profiles:
+    - default
+  telemetry:
+    type: Istiod
+  tracing:
+    sampling: 10000
+    type: Jaeger
+  version: v2.1


### PR DESCRIPTION
This commit is not chaning default behavior of OSSM installation script
but it allows to install Kiali for tests which require it. It also
improves robustness of OSSM install/delete scripts to make it work
reliably also on slower envs.

This change is required for a test John O'Hara is working on.